### PR TITLE
[Add]Kaminari Templete

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -1,6 +1,6 @@
 class Admin::ItemsController < ApplicationController
   def index
-    @items = Item.all
+    @items = Item.all.page(params[:page]).per(10)
   end
 
   def new

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -6,11 +6,11 @@
       </div>
     </div>
     <div class="row">
-      <div class="mx-auto col-md-8">
+      <div class="mx-auto col-md-8 mb-5">
         <%= link_to new_admin_item_path do %>
           <i class="fas fa-folder-plus fa-2x" style="color:#ED52A1"></i>
         <% end %>
-        <table class="table mb-5">
+        <table class="table mb-5 text-center">
           <thead>
             <tr>
               <th>商品ID</th>
@@ -38,6 +38,7 @@
             <% end %>
           </tbody>
         </table>
+        <%= paginate @items%>
       </div>
     </div>
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -11,7 +11,7 @@
           <% end %>
           <span class="small pl-3">(全<%= @items.count %>件)</span>
         </h2>
-        <div class="d-flex justify-content-start flex-wrap">
+        <div class="d-flex justify-content-start flex-wrap mb-5">
           <% @items.each do |item| %>
             <%= link_to item_path(item.id), class: "card m-2 stretched-link" do %>
               <%= attachment_image_tag item, :image, format: '.jpeg', class: "bd-placeholder-img card-img-top", size: "180x120" %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -9,7 +9,7 @@
           <% else %>
             <%= "#{@category.name}一覧" %>
           <% end %>
-          <span class="small pl-3">(全<%= @items.count %>件)</span>
+          <span class="small pl-3">(全<%= @items.total_count %>件)</span>
         </h2>
         <div class="d-flex justify-content-start flex-wrap mb-5">
           <% @items.each do |item| %>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination pagination-sm justify-content-center">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>


### PR DESCRIPTION
- kaminariのデザイン統一のため、kaminari専用のviewを新設しました　※gem採用は見送りました。
　（主に/naganocake/app/views/kaminari/_paginator.html.erb）
- 部分テンプレートの活用によりそれぞれ下記の記述だけでデザインが自動反映されるようにしています。
　【コントローラ】@items = Item.all.page(params[:page]).per(任意)
　【ビューページ】<%= paginate @items %>
　※_paginator.html.erbでは【pagination-sm justify-content-center】のクラス名が自動デザインの心臓部です。
　※パジネーションのデザイン統一のため、my-5やmb-5/mt-5を使用して上下を均等の余白にしてください。
　※余白をどの親要素に記述するかは担当箇所ごとにお任せしますが、部分テンプレートは触れないでください。

- kaminariを導入するとcountメソッドがpaginateされた件数分しか引っ張ってこない仕様を下記で解決しました。
　【<%= @items.count %>】→【<%= @items.total_count %>】